### PR TITLE
[BUGFIX] Avoid repercussions from changes in site configuration form definition

### DIFF
--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -132,11 +132,17 @@ $GLOBALS['SiteConfiguration']['site']['columns']['forwardRedirectParameters'] = 
     ],
 ];
 
-$GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] = str_replace(
-    'base,',
-    'base,--div--;LLL:EXT:language_detection/Resources/Private/Language/locallang.xlf:language.detection,enableLanguageDetection,allowAllPaths,fallbackDetectionLanguage,addIpLocationToBrowserLanguage,redirectHttpStatusCode,disableRedirectWithBackendSession,forwardRedirectParameters,--palette--;MaxMind;languageDetectionMaxMind,',
-    $GLOBALS['SiteConfiguration']['site']['types']['0']['showitem']
-);
+$GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] .=
+    ',--div--;LLL:EXT:language_detection/Resources/Private/Language/locallang.xlf:language.detection,
+        enableLanguageDetection,
+        allowAllPaths,
+        fallbackDetectionLanguage,
+        addIpLocationToBrowserLanguage,
+        redirectHttpStatusCode,
+        disableRedirectWithBackendSession,
+        forwardRedirectParameters,
+        --palette--;MaxMind;languageDetectionMaxMind,
+    ';
 
 $GLOBALS['SiteConfiguration']['site_language']['columns']['excludeFromLanguageDetection'] = [
     'label' => 'LLL:EXT:language_detection/Resources/Private/Language/locallang.xlf:exclude.language.from.detection',
@@ -146,8 +152,4 @@ $GLOBALS['SiteConfiguration']['site_language']['columns']['excludeFromLanguageDe
     ],
 ];
 
-$GLOBALS['SiteConfiguration']['site_language']['types']['1']['showitem'] = str_replace(
-    'flag,',
-    'flag, excludeFromLanguageDetection, ',
-    $GLOBALS['SiteConfiguration']['site_language']['types']['1']['showitem']
-);
+$GLOBALS['SiteConfiguration']['site_language']['types']['1']['showitem'] .= ', excludeFromLanguageDetection, ';


### PR DESCRIPTION
As the form definition changes from version to version, it's safer to append additional tabs & fields at the end of the configuration.
I.e.: In TYPO3 13 the dependencies field was hijacked to the language detection tab ...