### PR TITLE
feat: Add ip anonymization option

### DIFF
--- a/Classes/Detect/GeoPluginDetect.php
+++ b/Classes/Detect/GeoPluginDetect.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Lochmueller\LanguageDetection\Detect;
 
 use Lochmueller\LanguageDetection\Domain\Model\Dto\LocaleValueObject;
+use Lochmueller\LanguageDetection\Domain\Model\Dto\SiteConfiguration;
 use Lochmueller\LanguageDetection\Event\DetectUserLanguagesEvent;
+use Lochmueller\LanguageDetection\Service\IpAnonymizationService;
 use Lochmueller\LanguageDetection\Service\IpLocation;
 use Lochmueller\LanguageDetection\Service\LanguageService;
 use Lochmueller\LanguageDetection\Service\LocaleCollectionSortService;
@@ -21,6 +23,7 @@ use Psr\Http\Message\ServerRequestInterface;
 class GeoPluginDetect
 {
     public function __construct(
+        protected IpAnonymizationService $ipAnonymizationService,
         protected IpLocation $ipLocation,
         protected LanguageService $languageService,
         protected SiteConfigurationService $siteConfigurationService,
@@ -29,12 +32,13 @@ class GeoPluginDetect
 
     public function __invoke(DetectUserLanguagesEvent $event): void
     {
-        $addIp = $this->siteConfigurationService->getConfiguration($event->getSite())->getAddIpLocationToBrowserLanguage();
+        $configuration = $this->siteConfigurationService->getConfiguration($event->getSite());
+        $addIp = $configuration->getAddIpLocationToBrowserLanguage();
         if (!\in_array($addIp, [LocaleCollectionSortService::SORT_BEFORE, LocaleCollectionSortService::SORT_AFTER, LocaleCollectionSortService::SORT_REPLACE], true)) {
             return;
         }
 
-        $locale = $this->getLocale($event->getRequest());
+        $locale = $this->getLocale($event->getRequest(), $configuration);
         if ($locale === null) {
             return;
         }
@@ -42,9 +46,9 @@ class GeoPluginDetect
         $event->setUserLanguages($this->localeCollectionSortService->addLocaleByMode($event->getUserLanguages(), new LocaleValueObject($locale), $addIp));
     }
 
-    public function getLocale(ServerRequestInterface $request): ?string
+    public function getLocale(ServerRequestInterface $request, SiteConfiguration $configuration): ?string
     {
-        $countryCode = $this->ipLocation->getCountryCode($request->getServerParams()['REMOTE_ADDR'] ?? '');
+        $countryCode = $this->ipLocation->getCountryCode($this->ipAnonymizationService->anonymizeIpAddress($request->getServerParams()['REMOTE_ADDR'] ?? '', $configuration->getIpAddressPrecision()));
         if ($countryCode === null) {
             return null;
         }

--- a/Classes/Detect/MaxMindDetect.php
+++ b/Classes/Detect/MaxMindDetect.php
@@ -10,6 +10,7 @@ use GeoIp2\WebService\Client;
 use Lochmueller\LanguageDetection\Domain\Model\Dto\LocaleValueObject;
 use Lochmueller\LanguageDetection\Domain\Model\Dto\SiteConfiguration;
 use Lochmueller\LanguageDetection\Event\DetectUserLanguagesEvent;
+use Lochmueller\LanguageDetection\Service\IpAnonymizationService;
 use Lochmueller\LanguageDetection\Service\LanguageService;
 use Lochmueller\LanguageDetection\Service\LocaleCollectionSortService;
 use Lochmueller\LanguageDetection\Service\SiteConfigurationService;
@@ -18,6 +19,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class MaxMindDetect
 {
     public function __construct(
+        protected IpAnonymizationService $ipAnonymizationService,
         protected LanguageService $languageService,
         protected SiteConfigurationService $siteConfigurationService,
         protected LocaleCollectionSortService $localeCollectionSortService
@@ -32,8 +34,9 @@ class MaxMindDetect
             return;
         }
 
+        $ipAddress = $this->ipAnonymizationService->anonymizeIpAddress($event->getRequest()->getServerParams()['REMOTE_ADDR'] ?? '', $configuration->getIpAddressPrecision());
         try {
-            $result = $provider->country($event->getRequest()->getServerParams()['REMOTE_ADDR'] ?? '');
+            $result = $provider->country($ipAddress);
         } catch (\Exception) {
             return;
         }

--- a/Classes/Domain/Model/Dto/SiteConfiguration.php
+++ b/Classes/Domain/Model/Dto/SiteConfiguration.php
@@ -17,7 +17,8 @@ class SiteConfiguration
         protected string $maxMindDatabasePath,
         protected int $maxMindAccountId,
         protected string $maxMindLicenseKey,
-        protected string $maxMindMode
+        protected string $maxMindMode,
+        protected int $ipAddressPrecision
     ) {}
 
     public function isEnableLanguageDetection(): bool
@@ -73,5 +74,10 @@ class SiteConfiguration
     public function getMaxMindMode(): string
     {
         return $this->maxMindMode;
+    }
+
+    public function getIpAddressPrecision(): int
+    {
+        return $this->ipAddressPrecision;
     }
 }

--- a/Classes/Service/IpAnonymizationService.php
+++ b/Classes/Service/IpAnonymizationService.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lochmueller\LanguageDetection\Service;
+
+class IpAnonymizationService
+{
+    public function anonymizeIpAddress(string $ipAddress, int $precision): string
+    {
+        if ($precision === 4 || filter_var($ipAddress, FILTER_VALIDATE_IP) === false) {
+            return $ipAddress;
+        }
+
+        if (filter_var($ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+            $octets = explode('.', $ipAddress);
+            $zeroOctets = 4 - $precision;
+
+            for ($i = 3; $i >= 0 && $zeroOctets > 0; $i--, $zeroOctets--) {
+                $octets[$i] = '0';
+            }
+
+            return implode('.', $octets);
+        }
+
+        if (filter_var($ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+            $hextets = explode(':', $ipAddress);
+            $zeroHextets = (4 - $precision) * 2;
+
+            for ($i = 7; $i >= 0 && $zeroHextets > 0; $i--, $zeroHextets--) {
+                $hextets[$i] = '0000';
+            }
+
+            return implode(':', $hextets);
+        }
+
+        return $ipAddress;
+    }
+}

--- a/Classes/Service/SiteConfigurationService.php
+++ b/Classes/Service/SiteConfigurationService.php
@@ -26,6 +26,7 @@ class SiteConfigurationService
             (int)($config['languageDetectionMaxMindAccountId'] ?? ''),
             (string)($config['languageDetectionMaxMindLicenseKey'] ?? ''),
             (string)($config['languageDetectionMaxMindMode'] ?? 'After'),
+            (int)($config['ipAddressPrecision'] ?? 4),
         );
     }
 }

--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -52,6 +52,33 @@ $GLOBALS['SiteConfiguration']['site']['columns']['languageDetectionMaxMindMode']
     ],
 ];
 
+$GLOBALS['SiteConfiguration']['site']['columns']['ipAddressPrecision'] = [
+    'label' => 'LLL:EXT:language_detection/Resources/Private/Language/locallang.xlf:ipAddressPrecision',
+    'description' => 'LLL:EXT:language_detection/Resources/Private/Language/locallang.xlf:ipAddressPrecision.description',
+    'config' => [
+        'type' => 'select',
+        'renderType' => 'selectSingle',
+        'items' => [
+            [
+                'label' => '4 (Precise)',
+                'value' => '4',
+            ],
+            [
+                'label' => '3 (High precision)',
+                'value' => '3',
+            ],
+            [
+                'label' => '2 (Medium precision)',
+                'value' => '2',
+            ],
+            [
+                'label' => '1 (Low precision)',
+                'value' => '1',
+            ],
+        ],
+    ],
+];
+
 $GLOBALS['SiteConfiguration']['site']['columns']['addIpLocationToBrowserLanguage'] = [
     'label' => 'LLL:EXT:language_detection/Resources/Private/Language/locallang.xlf:ip.location.to.language',
     'config' => [
@@ -122,6 +149,7 @@ $GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] .=
         disableRedirectWithBackendSession,
         forwardRedirectParameters,
         --palette--;MaxMind;languageDetectionMaxMind,
+        ipAddressPrecision,
     ';
 
 $GLOBALS['SiteConfiguration']['site_language']['columns']['excludeFromLanguageDetection'] = [

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -35,6 +35,12 @@
 			<trans-unit id="languageDetectionMaxMindMode">
 				<source>Location for the maxmind detection (mode)</source>
 			</trans-unit>
+			<trans-unit id="ipAddressPrecision">
+				<source>IP address precision</source>
+			</trans-unit>
+			<trans-unit id="ipAddressPrecision.description">
+				<source>4 retains the full IP address, 3 removes the last octet, etc.</source>
+			</trans-unit>
 			<trans-unit id="allow.all.paths">
 				<source>Allow all paths (otherwise the detection works only on "/")</source>
 			</trans-unit>

--- a/Tests/Unit/Detect/MaxMindDetectTest.php
+++ b/Tests/Unit/Detect/MaxMindDetectTest.php
@@ -7,6 +7,7 @@ namespace Lochmueller\LanguageDetection\Tests\Unit\Detect;
 use Lochmueller\LanguageDetection\Detect\MaxMindDetect;
 use Lochmueller\LanguageDetection\Domain\Collection\LocaleCollection;
 use Lochmueller\LanguageDetection\Event\DetectUserLanguagesEvent;
+use Lochmueller\LanguageDetection\Service\IpAnonymizationService;
 use Lochmueller\LanguageDetection\Service\LanguageService;
 use Lochmueller\LanguageDetection\Service\LocaleCollectionSortService;
 use Lochmueller\LanguageDetection\Service\SiteConfigurationService;
@@ -39,7 +40,7 @@ class MaxMindDetectTest extends AbstractUnitTest
         $event = new DetectUserLanguagesEvent($site, $serverRequest);
         $event->setUserLanguages(LocaleCollection::fromArray(['default']));
 
-        $maxMindDetect = new MaxMindDetect(new LanguageService(), new SiteConfigurationService(), new LocaleCollectionSortService());
+        $maxMindDetect = new MaxMindDetect(new IpAnonymizationService(), new LanguageService(), new SiteConfigurationService(), new LocaleCollectionSortService());
         $maxMindDetect($event);
 
         self::assertCount(1, $event->getUserLanguages()->toArray());
@@ -70,21 +71,21 @@ class MaxMindDetectTest extends AbstractUnitTest
         self::assertExecutionTimeLessThenOrEqual(0.3, function () use ($site, $serverRequest): void {
             $event = new DetectUserLanguagesEvent($site, $serverRequest);
             $event->setUserLanguages(LocaleCollection::fromArray([]));
-            $maxMindDetect = new MaxMindDetect(new LanguageService(), new SiteConfigurationService(), new LocaleCollectionSortService());
+            $maxMindDetect = new MaxMindDetect(new IpAnonymizationService(), new LanguageService(), new SiteConfigurationService(), new LocaleCollectionSortService());
             $maxMindDetect($event);
         });
 
         self::assertExecutionMemoryLessThenOrEqual(400, function () use ($site, $serverRequest): void {
             $event = new DetectUserLanguagesEvent($site, $serverRequest);
             $event->setUserLanguages(LocaleCollection::fromArray([]));
-            $maxMindDetect = new MaxMindDetect(new LanguageService(), new SiteConfigurationService(), new LocaleCollectionSortService());
+            $maxMindDetect = new MaxMindDetect(new IpAnonymizationService(), new LanguageService(), new SiteConfigurationService(), new LocaleCollectionSortService());
             $maxMindDetect($event);
         });
 
         // regular Execution
         $event = new DetectUserLanguagesEvent($site, $serverRequest);
         $event->setUserLanguages(LocaleCollection::fromArray([]));
-        $maxMindDetect = new MaxMindDetect(new LanguageService(), new SiteConfigurationService(), new LocaleCollectionSortService());
+        $maxMindDetect = new MaxMindDetect(new IpAnonymizationService(), new LanguageService(), new SiteConfigurationService(), new LocaleCollectionSortService());
         $maxMindDetect($event);
 
         $languages = $event->getUserLanguages()->toArray();

--- a/Tests/Unit/Domain/Model/Dto/SiteConfigurationTest.php
+++ b/Tests/Unit/Domain/Model/Dto/SiteConfigurationTest.php
@@ -30,7 +30,8 @@ class SiteConfigurationTest extends AbstractUnitTest
             'path.mmdb',
             42,
             'abcd',
-            'After'
+            'After',
+            2
         );
 
         self::assertTrue($dto->isEnableLanguageDetection());

--- a/Tests/Unit/Service/IpAnonymizationServiceTest.php
+++ b/Tests/Unit/Service/IpAnonymizationServiceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lochmueller\LanguageDetection\Tests\Unit\Service;
+
+use Lochmueller\LanguageDetection\Service\IpAnonymizationService;
+use Lochmueller\LanguageDetection\Tests\Unit\AbstractUnitTest;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class IpAnonymizationServiceTest extends AbstractUnitTest
+{
+    /**
+     * @covers \Lochmueller\LanguageDetection\Service\IpAnonymizationService
+     */
+    public function testIpAddressAnonymizationForIpV4(): void
+    {
+        $ipAnonymizationService = new IpAnonymizationService();
+        $ipv4 = '192.168.12.34';
+
+        self::assertSame('192.168.12.34', $ipAnonymizationService->anonymizeIpAddress($ipv4, 4));
+        self::assertSame('192.168.12.0', $ipAnonymizationService->anonymizeIpAddress($ipv4, 3));
+        self::assertSame('192.168.0.0', $ipAnonymizationService->anonymizeIpAddress($ipv4, 2));
+        self::assertSame('192.0.0.0', $ipAnonymizationService->anonymizeIpAddress($ipv4, 1));
+    }
+
+    /**
+     * @covers \Lochmueller\LanguageDetection\Service\IpAnonymizationService
+     */
+    public function testIpAddressAnonymizationForIpV6(): void
+    {
+        $ipAnonymizationService = new IpAnonymizationService();
+        $ipv6 = '2001:0db8:85a3:0000:0000:8a2e:0370:7334';
+
+        self::assertSame('2001:0db8:85a3:0000:0000:8a2e:0370:7334', $ipAnonymizationService->anonymizeIpAddress($ipv6, 4));
+        self::assertSame('2001:0db8:85a3:0000:0000:8a2e:0000:0000', $ipAnonymizationService->anonymizeIpAddress($ipv6, 3));
+        self::assertSame('2001:0db8:85a3:0000:0000:0000:0000:0000', $ipAnonymizationService->anonymizeIpAddress($ipv6, 2));
+        self::assertSame('2001:0db8:0000:0000:0000:0000:0000:0000', $ipAnonymizationService->anonymizeIpAddress($ipv6, 1));
+    }
+
+    /**
+     * @covers \Lochmueller\LanguageDetection\Service\IpAnonymizationService
+     */
+    public function testIpAddressAnonymizationForInvalidIp(): void
+    {
+        $ipAnonymizationService = new IpAnonymizationService();
+
+        self::assertSame('not-an-ip', $ipAnonymizationService->anonymizeIpAddress('not-an-ip', 3));
+    }
+}


### PR DESCRIPTION
Introduced the option to anonymize IPv4/IPv6 addresses based on a configurable precision. This is integrated into MaxMindDetect and GeoPluginDetect to ensure IPs are anonymized before querying for country detection.